### PR TITLE
Fix for #34 - Pre-1970 dates causes OverflowError

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.10.2] - Unreleased
+
+### Fixed
+
+- #34 - Pre-1970 dates causes OverflowError
+
 ## [1.10.1] - 2023-12-21
 
 ### Fixed

--- a/src/firebird/driver/core.py
+++ b/src/firebird/driver/core.py
@@ -3328,7 +3328,7 @@ class Cursor(LoggingIdMixin):
                                          in_meta.get_subtype(i), scale)
                     memmove(buf_addr + offset, value.to_bytes(length, 'little', signed=True), length)
                 elif datatype == SQLDataType.DATE:
-                    memmove(buf_addr + offset, _util.encode_date(value).to_bytes(length, 'little'), length)
+                    memmove(buf_addr + offset, _util.encode_date(value).to_bytes(length, 'little', signed=True), length)
                 elif datatype == SQLDataType.TIME:
                     memmove(buf_addr + offset, _util.encode_time(value).to_bytes(length, 'little'), length)
                 elif datatype == SQLDataType.TIME_TZ:

--- a/tests/test_driver.py
+++ b/tests/test_driver.py
@@ -1475,6 +1475,16 @@ class TestInsertData(DriverTestBase):
             self.assertListEqual(rows,
                                  [(4, datetime.date(2011, 11, 13), datetime.time(15, 0, 1, 200000),
                                    datetime.datetime(2011, 11, 13, 15, 0, 1, 200000))])
+
+            # encode date before 1859-11-17 produce a negative number
+            now = datetime.datetime(1859, 11, 16, 15, 0, 1, 200000)
+            cur.execute('insert into T2 (C1,C6,C7,C8) values (?,?,?,?)', [5, now.date(), now.time(), now])
+            self.con.commit()
+            cur.execute('select C1,C6,C7,C8 from T2 where C1 = 5')
+            rows = cur.fetchall()
+            self.assertListEqual(rows,
+                                 [(5, datetime.date(1859, 11, 16), datetime.time(15, 0, 1, 200000),
+                                   datetime.datetime(1859, 11, 16, 15, 0, 1, 200000))])
     def test_insert_blob(self):
         with self.con.cursor() as cur, self.con2.cursor() as cur2:
             cur.execute('insert into T2 (C1,C9) values (?,?)', [4, 'This is a BLOB!'])


### PR DESCRIPTION
Hi.

This merge request should fix #34 issue.

With the fix, I have added an assertion to validate the behavior of data insertion, but I was unable to run the tests because I haven't a working Firebird server on my computer.

I have tested the fix with a Python project that uses SQLAlchemy, it works in this context and the test suite has not found any regression.