### PR TITLE
Remove extra newline in readline_timed().

### DIFF
--- a/src/firebird/driver/core.py
+++ b/src/firebird/driver/core.py
@@ -5723,9 +5723,7 @@ class Server:
         data = self.response.read_sized_string(encoding=self.encoding, errors=self.encoding_errors)
         if self.response.get_tag() == SrvInfoCode.TIMEOUT:
             return TIMEOUT
-        if data:
-            return data + '\n'
-        return None
+        return data if data else None
     def readline(self) -> str | None:
         """Get next line of textual output from last service query.
 

--- a/src/firebird/driver/core.py
+++ b/src/firebird/driver/core.py
@@ -5723,6 +5723,10 @@ class Server:
         data = self.response.read_sized_string(encoding=self.encoding, errors=self.encoding_errors)
         if self.response.get_tag() == SrvInfoCode.TIMEOUT:
             return TIMEOUT
+        # read_sized_string() returns lines ending with '\r ' (CR + space).
+        # Strip the trailing space to get proper '\r' line endings.
+        if data and data.endswith('\r '):
+            data = data[:-1]  # Remove space, keep '\r'
         return data if data else None
     def readline(self) -> str | None:
         """Get next line of textual output from last service query.


### PR DESCRIPTION
Fix for #58.

Running the demonstration script ([newline-problem.py](https://github.com/user-attachments/files/23571850/newline-problem.py)) after this fix generates both files correctly.


[raw-trace-fbtracemgr.txt](https://github.com/user-attachments/files/23572045/raw-trace-fbtracemgr.txt):
```
2025-11-16T21:37:16.6010 (57764:0000000002500D40) ATTACH_DATABASE
	C:\PROGRAM FILES\FIREBIRD\FIREBIRD_3_0\EXAMPLES\EMPBUILD\EMPLOYEE.FDB (ATT_99, SYSDBA:NONE, NONE, XNET:)
	C:\Users\fdcastel.TOLKIEN\AppData\Roaming\uv\python\cpython-3.11.11-windows-x86_64-none\python.exe:26704

2025-11-16T21:37:16.6010 (57764:0000000002500D40) START_TRANSACTION
	C:\PROGRAM FILES\FIREBIRD\FIREBIRD_3_0\EXAMPLES\EMPBUILD\EMPLOYEE.FDB (ATT_99, SYSDBA:NONE, NONE, XNET:)
	C:\Users\fdcastel.TOLKIEN\AppData\Roaming\uv\python\cpython-3.11.11-windows-x86_64-none\python.exe:26704
		(TRA_189, CONCURRENCY | WAIT | READ_WRITE)

2025-11-16T21:37:16.6010 (57764:0000000002500D40) EXECUTE_STATEMENT_START
	C:\PROGRAM FILES\FIREBIRD\FIREBIRD_3_0\EXAMPLES\EMPBUILD\EMPLOYEE.FDB (ATT_99, SYSDBA:NONE, NONE, XNET:)
	C:\Users\fdcastel.TOLKIEN\AppData\Roaming\uv\python\cpython-3.11.11-windows-x86_64-none\python.exe:26704
		(TRA_189, CONCURRENCY | WAIT | READ_WRITE)

```


[raw-trace-python3-driver.txt](https://github.com/user-attachments/files/23572047/raw-trace-python3-driver.txt):
```
2025-11-16T21:37:20.8960 (57764:0000000002500D40) ATTACH_DATABASE
	C:\PROGRAM FILES\FIREBIRD\FIREBIRD_3_0\EXAMPLES\EMPBUILD\EMPLOYEE.FDB (ATT_102, SYSDBA:NONE, NONE, XNET:)
	C:\Users\fdcastel.TOLKIEN\AppData\Roaming\uv\python\cpython-3.11.11-windows-x86_64-none\python.exe:26704

2025-11-16T21:37:20.8970 (57764:0000000002500D40) START_TRANSACTION
	C:\PROGRAM FILES\FIREBIRD\FIREBIRD_3_0\EXAMPLES\EMPBUILD\EMPLOYEE.FDB (ATT_102, SYSDBA:NONE, NONE, XNET:)
	C:\Users\fdcastel.TOLKIEN\AppData\Roaming\uv\python\cpython-3.11.11-windows-x86_64-none\python.exe:26704
		(TRA_190, CONCURRENCY | WAIT | READ_WRITE)

2025-11-16T21:37:20.8990 (57764:0000000002500D40) EXECUTE_STATEMENT_START
	C:\PROGRAM FILES\FIREBIRD\FIREBIRD_3_0\EXAMPLES\EMPBUILD\EMPLOYEE.FDB (ATT_102, SYSDBA:NONE, NONE, XNET:)
	C:\Users\fdcastel.TOLKIEN\AppData\Roaming\uv\python\cpython-3.11.11-windows-x86_64-none\python.exe:26704
		(TRA_190, CONCURRENCY | WAIT | READ_WRITE)

```
