### PR TITLE
Add `plugins` option support for TRACE_START and TRACE_LIST

### DIFF
--- a/src/firebird/driver/core.py
+++ b/src/firebird/driver/core.py
@@ -5581,6 +5581,8 @@ class ServerTraceServices(ServerServiceProvider):
                     '%Y-%m-%d %H:%M:%S')
             elif line.lstrip().startswith('flags:'):
                 current['flags'] = line.split(':')[1].strip().split(',')
+            elif line.lstrip().startswith('plugins:'):
+                current['plugins'] = line.split(':')[1].strip().split(',')
             else:  # pragma: no cover
                 raise InterfaceError(f"Unexpected line in trace session list: {line}")
         store()

--- a/src/firebird/driver/core.py
+++ b/src/firebird/driver/core.py
@@ -5496,12 +5496,13 @@ class ServerTraceServices(ServerServiceProvider):
             # response should contain the error message
             raise DatabaseError(response)
         return response
-    def start(self, *, config: str, name: str | None=None) -> int:
+    def start(self, *, config: str, name: str | None=None, plugins: str | list[str] | None) -> int:
         """Start new trace session. **(ASYNC service)**
 
         Arguments:
             config: Trace session configuration.
             name: Trace session name.
+            plugins: Plugins to use for the session (only for FIREBIRD 6+)
 
         Returns:
             Trace session ID.
@@ -5511,6 +5512,11 @@ class ServerTraceServices(ServerServiceProvider):
             spb.insert_tag(ServerAction.TRACE_START)
             if name is not None:
                 spb.insert_string(SrvTraceOption.NAME, name)
+            if plugins is not None:
+                if isinstance(plugins, list):
+                    plugins = ",".join(plugins)
+                spb.insert_string(SrvTraceOption.PLUGINS, plugins)
+
             spb.insert_string(SrvTraceOption.CONFIG, config, encoding=self._srv().encoding)
             self._srv()._svc.start(spb.get_buffer())
         response = self._srv()._fetch_line()

--- a/src/firebird/driver/types.py
+++ b/src/firebird/driver/types.py
@@ -830,6 +830,7 @@ class SrvTraceOption(IntEnum):
     ID = 1
     NAME = 2
     CONFIG = 3
+    PLUGINS = 4
 
 class SrvPropertiesOption(IntEnum):
     """Parameters for ServerAction.PROPERTIES.

--- a/src/firebird/driver/types.py
+++ b/src/firebird/driver/types.py
@@ -1372,12 +1372,14 @@ class TraceSession:
         timestamp (datetime.datetime): Session start timestamp
         name (str): Session name (if defined)
         flags (list): List with session flag names
+        plugins (list): List with trace plugins for this session
     """
     id: int
     user: str
     timestamp: datetime.datetime
     name: str = ''
     flags: list = field(default_factory=list)
+    plugins: list = field(default_factory=list)
 
 @dataclass
 class ImpData:

--- a/src/test.py
+++ b/src/test.py
@@ -1,0 +1,24 @@
+import sys
+import os
+
+from firebird.driver.fbapi import load_api
+sys.path.append(os.getcwd())
+script_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(script_dir)
+from firebird.driver.core import connect_server
+
+load_api("/home/artmkn/wspace/reps/rdb5trace/gen/Debug/firebird/lib/libfbclient.so")
+
+with connect_server('', user='SYSDBA', password='masterkey') as srv:
+
+    trace_session_id = srv.trace.start(config="#MESSAGETRACE\ndatabase\n{\nenabled = true\n}", name="messagetrace")
+    print(trace_session_id)
+
+    a = input()
+    # K = 1
+    # V = TraceSession(id=1, user='SYSDBA', timestamp=..., name=<LONG_NAME_OF_TRACE_SESSION>, flags=['active', ' trace'])
+    # for k,v in srv.trace.sessions.items():
+    #     if v.flags[0] == 'active':
+    #         print(f"Trace {v.name}: Plugins: {v.plugins}")
+
+


### PR DESCRIPTION
Add support for the `plugin` option for user trace session (introduced in the https://github.com/FirebirdSQL/firebird/pull/8707 )

This should solve https://github.com/FirebirdSQL/python3-driver/issues/55

Examples:
```python
with connect_server('', user='SYSDBA', password='masterkey') as srv:
    trace_session_id = srv.trace.start(config="database\n{\nenabled = true\n}", name="mytrace", plugins=["myplugin","fbtrace"])
    print(trace_session_id)
```

```python
with connect_server('', user='SYSDBA', password='masterkey') as srv:
    for k,v in srv.trace.sessions.items():
        if v.flags[0] == 'active':
            print(f"Trace {v.name}: Plugins: {v.plugins}")
```
