### PR TITLE
Fix segfault in garbage collection of abandoned connection (#69)

### DIFF
--- a/src/firebird/driver/interfaces.py
+++ b/src/firebird/driver/interfaces.py
@@ -1261,9 +1261,15 @@ class iAttachment(iAttachment_v4):
     VERSION = 5
     def detach(self) -> None:
         "Replaces `isc_detach_database()`. On success releases interface."
-        self.vtable.detach(self, self.status)
-        self._check()
-        self._refcnt -= 1
+        # Guard against detaching an already-released interface. During cyclic
+        # garbage collection the iAttachment's own iReferenceCounted.__del__
+        # may run release() before Connection.__del__ calls detach(); without
+        # this guard the native call dereferences freed memory and segfaults
+        # (issue #69). iAttachment_v4.detach already guards the same way.
+        if self._refcnt:
+            self.vtable.detach(self, self.status)
+            self._check()
+            self._refcnt -= 1
     def drop_database(self) -> None:
         "Replaces `isc_drop_database()`. On success releases interface."
         self.vtable.dropDatabase(self, self.status)

--- a/tests/test_issues.py
+++ b/tests/test_issues.py
@@ -65,3 +65,52 @@ def test_issue_65_free_then_conn_close(dsn):
         row = cur.execute(stmt, (2,)).fetchone()
         assert row is not None
         stmt.free()
+
+def test_issue_69_gc_of_abandoned_connection(dsn):
+    """A connection abandoned without close() and reclaimed by cyclic garbage
+    collection must not crash in Connection.__del__ -> iAttachment.detach().
+
+    During cyclic GC the iAttachment's own iReferenceCounted.__del__ may run
+    release() (dropping its refcount to 0 and freeing the native interface)
+    before Connection.__del__ calls detach(); detaching the already-released
+    interface dereferences freed memory and segfaults.
+
+    On Python builds where the access violation hard-crashes the process the
+    worker dies (test fails). On builds where ctypes turns it into an
+    "Exception ignored ... in __del__" the failure is delivered via
+    sys.unraisablehook, which this test captures.
+    """
+    import gc
+    import sys
+    import warnings
+    from firebird.driver import connect
+
+    def abandon():
+        con = connect(dsn)
+        cur = con.cursor()
+        cur.execute('select count(*) from country')
+        cur.fetchall()
+        # deliberately NO con.close(); the reference is dropped on return
+
+    unraisable = []
+    old_hook = sys.unraisablehook
+    sys.unraisablehook = unraisable.append
+    try:
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter('always')
+            for _ in range(5):
+                abandon()
+            gc.collect()
+    finally:
+        sys.unraisablehook = old_hook
+
+    # The #69 crash is a native access violation (surfaced as OSError) escaping
+    # the finalizer; on hard-crashing builds the worker dies before reaching
+    # here. Other finalizer noise (e.g. a benign "invalid transaction handle"
+    # DatabaseError seen on some versions) is unrelated to this issue.
+    access_violations = [a for a in unraisable
+                         if isinstance(a.exc_value, OSError)]
+    assert not access_violations, \
+        f"finalizer access violation: {[a.exc_value for a in access_violations]}"
+    # The finalizer must still run and warn about the undisposed connection.
+    assert any(issubclass(w.category, ResourceWarning) for w in caught)


### PR DESCRIPTION
Fixes #69.

## Problem

Abandoning a `firebird.driver.connect()` connection without calling `close()` and letting it be reclaimed by cyclic garbage collection crashes in `Connection.__del__` → `iAttachment.detach()` — a native access violation (a "Windows fatal exception: access violation" hard crash, or an "Exception ignored … in `__del__`" depending on the Python build). Reported on Python 3.13; reproduces with the Firebird 4.0 and 5.0 client libraries.

## Root cause

`iAttachment_v4.detach()` guards the native call with `if self._refcnt:`, but the v5 `iAttachment.detach()` override dropped that guard:

```python
# iAttachment (v5)
def detach(self) -> None:
    self.vtable.detach(self, self.status)
    self._check()
    self._refcnt -= 1
```

During cyclic GC the `iAttachment`'s own `iReferenceCounted.__del__` can run `release()` first — freeing the native interface and setting `_refcnt` to 0 — before `Connection.__del__` calls `detach()`. The unguarded `detach()` then dereferences the already-released interface and crashes.

Confirmed by instrumenting `Connection.__del__`: at the crash `self._att._refcnt == 0` (the interface was already released) while the access violation is a write to `NULL + 0x24`.

## Fix

Restore the `if self._refcnt:` guard on the v5 `iAttachment.detach()`, matching `iAttachment_v4.detach()`. `close()` is unaffected (it detaches while `_refcnt == 1`); only the GC/`__del__` path, where the interface has already been released, becomes a safe no-op.

## Testing

Added `test_issue_69_gc_of_abandoned_connection`: it abandons several connections without `close()`, forces cyclic GC, and asserts (via `sys.unraisablehook`) that no access violation escapes the finalizer.

Verified against Firebird 3.0 / 4.0 / 5.0:
- The new test **fails** on the current code with the FB 4.0 and 5.0 clients and **passes** with the fix. FB 3.0 uses the already-guarded v3 interface and was never affected (the test passes there with or without the fix).
- The rest of the existing suite shows no new failures.
