### PR TITLE
Make ServerTraceServices.start() plugins argument optional (regression from #68)

### DIFF
--- a/src/firebird/driver/core.py
+++ b/src/firebird/driver/core.py
@@ -5496,7 +5496,7 @@ class ServerTraceServices(ServerServiceProvider):
             # response should contain the error message
             raise DatabaseError(response)
         return response
-    def start(self, *, config: str, name: str | None=None, plugins: str | list[str] | None) -> int:
+    def start(self, *, config: str, name: str | None=None, plugins: str | list[str] | None=None) -> int:
         """Start new trace session. **(ASYNC service)**
 
         Arguments:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -22,6 +22,7 @@
 #
 # See LICENSE.TXT for details.
 
+import inspect
 from io import BytesIO
 import pytest
 from packaging.specifiers import SpecifierSet
@@ -157,6 +158,19 @@ def test_get_limbo_transaction_ids(server_connection, db_file):
     pytest.skip('Not implemented yet')
     ids = server_connection.database.get_limbo_transaction_ids(database=str(db_file))
     assert isinstance(ids, type(list()))
+
+def test_trace_start_plugins_is_optional():
+    """Regression: ServerTraceServices.start() must keep `plugins` optional.
+
+    #68 added `plugins` as a keyword-only parameter but without a default,
+    making it required and breaking every existing caller (including
+    `test_trace` below, and any FB3/4/5 user) with
+    "missing 1 required keyword-only argument: 'plugins'". The method body
+    already treats it as optional (`if plugins is not None:`) and the
+    docstring marks it FB6+ only, so it must default to None.
+    """
+    sig = inspect.signature(driver.core.ServerTraceServices.start)
+    assert sig.parameters['plugins'].default is None
 
 def test_trace(server_connection, db_file, fb_vars):
     trace_config = """database = %s


### PR DESCRIPTION
## Problem

`ServerTraceServices.start()` cannot be called the way it always has been:

```python
server.trace.start(config=trace_config, name='my_trace')
```

raises:

```
TypeError: ServerTraceServices.start() missing 1 required keyword-only argument: 'plugins'
```

This breaks every existing caller, including this repository's own
`tests/test_server.py::test_trace`.

## Root cause

#68 added a `plugins` keyword-only parameter to `start()`, but without a
default value, so it became **required**:

```python
def start(self, *, config: str, name: str | None=None, plugins: str | list[str] | None) -> int:
```

The method body already treats it as optional (`if plugins is not None:`) and
the docstring documents it as *"only for FIREBIRD 6+"*, so it was clearly
intended to be optional.

## Fix

Restore the `= None` default:

```python
def start(self, *, config: str, name: str | None=None, plugins: str | list[str] | None=None) -> int:
```

## Testing

Adds `test_trace_start_plugins_is_optional`, a server-free regression test
asserting `plugins` keeps a default of `None`. It fails on `master` and passes
with this change; the existing `test_trace` integration test also passes again.
